### PR TITLE
DMC-414 Fix HttpMediaTypeNotAcceptableException when Gemini connects to MCP stream endpoint

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/dto/McpStreamRequestParamsDto.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/dto/McpStreamRequestParamsDto.java
@@ -1,0 +1,56 @@
+package com.github.istin.dmtools.dto;
+
+import org.json.JSONObject;
+
+public class McpStreamRequestParamsDto {
+    private String method;
+    private String id; // Can be String or Integer, use String for flexibility
+    private String params; // JSON string for the params object
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getParams() {
+        return params;
+    }
+
+    public void setParams(String params) {
+        this.params = params;
+    }
+
+    public JSONObject toJSONObject() {
+        JSONObject json = new JSONObject();
+        json.put("jsonrpc", "2.0"); // MCP protocol always uses 2.0
+        json.put("method", method);
+        if (id != null) {
+            try {
+                json.put("id", Integer.parseInt(id));
+            } catch (NumberFormatException e) {
+                json.put("id", id);
+            }
+        }
+        if (params != null && !params.isEmpty()) {
+            try {
+                json.put("params", new JSONObject(params));
+            } catch (Exception e) {
+                // Log error or handle invalid JSON params
+                System.err.println("Invalid JSON for params: " + params + " - " + e.getMessage());
+                json.put("params", new JSONObject()); // Default to empty object
+            }
+        }
+        return json;
+    }
+}

--- a/dmtools-server/src/test/java/com/github/istin/dmtools/server/controller/DynamicMCPControllerTest.java
+++ b/dmtools-server/src/test/java/com/github/istin/dmtools/server/controller/DynamicMCPControllerTest.java
@@ -1,0 +1,132 @@
+package com.github.istin.dmtools.server.controller;
+
+import com.github.istin.dmtools.auth.controller.DynamicMCPController;
+import com.github.istin.dmtools.auth.model.McpConfiguration;
+import com.github.istin.dmtools.auth.model.User;
+import com.github.istin.dmtools.auth.service.IntegrationConfigurationLoader;
+import com.github.istin.dmtools.auth.service.IntegrationService;
+import com.github.istin.dmtools.auth.service.McpConfigurationService;
+import com.github.istin.dmtools.server.service.FileDownloadService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class DynamicMCPControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private McpConfigurationService mcpConfigurationService;
+
+    @Mock
+    private IntegrationService integrationService;
+
+    @Mock
+    private IntegrationConfigurationLoader configurationLoader;
+
+    @Mock
+    private FileDownloadService fileDownloadService;
+
+    @InjectMocks
+    private DynamicMCPController dynamicMCPController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(dynamicMCPController).build();
+    }
+
+    @Test
+    void mcpStreamGet_shouldReturnSseEmitter_whenConfigFound() throws Exception {
+        String configId = UUID.randomUUID().toString();
+        String userId = UUID.randomUUID().toString();
+        User user = new User();
+        user.setId(userId);
+
+        McpConfiguration mcpConfig = new McpConfiguration();
+        mcpConfig.setId(configId);
+        mcpConfig.setUser(user);
+        mcpConfig.setIntegrationIds(Collections.singletonList("jira"));
+
+        when(mcpConfigurationService.findById(anyString())).thenReturn(mcpConfig);
+
+        mockMvc.perform(get("/mcp/stream/{configId}", configId)
+                        .param("method", "initialize")
+                        .param("id", "1")
+                        .param("params", "{}")
+                        .accept(MediaType.TEXT_EVENT_STREAM))
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted());
+    }
+
+    @Test
+    void mcpStreamPost_shouldReturnSseEmitter_whenConfigFound() throws Exception {
+        String configId = UUID.randomUUID().toString();
+        String userId = UUID.randomUUID().toString();
+        User user = new User();
+        user.setId(userId);
+
+        McpConfiguration mcpConfig = new McpConfiguration();
+        mcpConfig.setId(configId);
+        mcpConfig.setUser(user);
+        mcpConfig.setIntegrationIds(Collections.singletonList("jira"));
+
+        when(mcpConfigurationService.findById(anyString())).thenReturn(mcpConfig);
+
+        String requestBody = "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1,\"params\":{}}";
+
+        mockMvc.perform(post("/mcp/stream/{configId}", configId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .accept(MediaType.TEXT_EVENT_STREAM))
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted());
+    }
+
+    @Test
+    void mcpStreamGet_shouldReturnError_whenConfigNotFound() throws Exception {
+        String configId = UUID.randomUUID().toString();
+
+        when(mcpConfigurationService.findById(anyString())).thenReturn(null);
+
+        mockMvc.perform(get("/mcp/stream/{configId}", configId)
+                        .param("method", "initialize")
+                        .param("id", "1")
+                        .param("params", "{}")
+                        .accept(MediaType.TEXT_EVENT_STREAM))
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted()); // Still async, error sent via emitter
+    }
+
+    @Test
+    void mcpStreamPost_shouldReturnError_whenConfigNotFound() throws Exception {
+        String configId = UUID.randomUUID().toString();
+
+        when(mcpConfigurationService.findById(anyString())).thenReturn(null);
+
+        String requestBody = "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1,\"params\":{}}";
+
+        mockMvc.perform(post("/mcp/stream/{configId}", configId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .accept(MediaType.TEXT_EVENT_STREAM))
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted()); // Still async, error sent via emitter
+    }
+}


### PR DESCRIPTION
# Error Response

**Generated:** Sat Aug 16 11:16:10 UTC 2025
**Phase:** implementation
**Model:** gemini-2.5-flash-preview-05-20
**Exit Code:** 1

---

## Error Output:
```
(node:6167) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. MaxListeners is 10. Use events.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
Error executing tool run_shell_command: Directory 'dmtools-server' is not a registered workspace directory.
```
