### PR TITLE
fix: Update url for oauth setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For complete OAuth2 setup instructions including:
 - ✅ **GitHub Actions** with secrets management
 - ✅ **Security configuration** and troubleshooting
 
-📖 **See the comprehensive guide**: [OAUTH_SETUP.md](OAUTH_SETUP.md)
+📖 **See the comprehensive guide**: [oauth-setup.md](docs/deployment/oauth-setup.md)
 
 ### Live Application
 - **Production**: https://ai-native.cloud


### PR DESCRIPTION
Fixed link to oauth setup instruction